### PR TITLE
:fire: remove .env file from initial project setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,20 @@
         source env/bin/activate
         pip install -r requirements.txt
     ```
-3. Ask Duc or one of the other developers for the `.env` file and place it in the root of the project
+3. optional: using your email to send email, create local_settings.py next to settings.py:
+    <font size="1" style="color:gray">-> make sure local_settings.py is in .gitingore</font>
+    ```python
+        SECRET_KEY = 'yoursecretkey' # eg:n!+$0%qf#$ldt7t5^7@a*%jo7s)yxe468av72z#hq)bx^+qu9d
+        DEBUG = True
+        EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+        EMAIL_HOST = '<your-email-host>' 
+        EMAIL_PORT = '<email-port>' # eg: 587
+        EMAIL_HOST_USER = 'youremail@example.com'
+        EMAIL_HOST_PASSWORD = 'your-password' #not support 2-Step Verification
+        EMAIL_USE_TLS = True
+    ```
+    *<font size="1">Set Google App Passwords info: https://support.google.com/accounts/answer/185833?hl=en</font>*
+    
 4. Setup database
     * Make sure you have modern version of Postgresql installed locally
     * from the console, run `createdb maskes`

--- a/maskes/settings.py
+++ b/maskes/settings.py
@@ -12,12 +12,6 @@ https://docs.djangoproject.com/en/3.0/ref/settings/
 
 import os
 from datetime import timedelta
-import environ
-
-root = environ.Path(__file__)
-env = environ.Env()
-environ.Env.read_env()
-
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -27,9 +21,9 @@ TEMPLATES_DIR = os.path.join(BASE_DIR, 'build')
 # See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = env.str('SECRET_KEY')
+SECRET_KEY = 'THIS-IS-A-DUMMY-KEY'
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = env('DEBUG')
+DEBUG = True
 
 ALLOWED_HOSTS = []
 
@@ -192,13 +186,10 @@ DJOSER = {
     'HIDE_USERS': True,
 }
 
-EMAIL_BACKEND = env('EMAIL_BACKEND')
-if EMAIL_BACKEND == "django.core.mail.backends.smtp.EmailBackend":
-    EMAIL_HOST = env('EMAIL_HOST')
-    EMAIL_PORT = env('EMAIL_PORT')
-    EMAIL_HOST_USER = env('EMAIL_HOST_USER')
-    EMAIL_HOST_PASSWORD = env('EMAIL_HOST_PASSWORD')
-    EMAIL_USE_TLS = True
+#Email will be setup in local_setting.py using environment variables
+#SECURITY WARNING: don't put your email info here
+#django dummy email backend will not send any email
+EMAIL_BACKEND = 'django.core.mail.backends.dummy.EmailBackend'
 
 
 AUTH_USER_MODEL = 'users.UserAccount'


### PR DESCRIPTION
1. new dev won't need .env when initially setup project.
2. we can create and import of local_settings.py which can use .env if needed